### PR TITLE
RealmeParts: Enable 90 Hz during game mode

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -56,6 +56,8 @@
     <string name="tile_game_mode">Game Mode</string>
     <string name="dnd_title">Do Not Disturb</string>
     <string name="dnd_summary">DND will be activated if Game Mode is enabled</string>
+    <string name="game_fps_title">Game FPS</string>
+    <string name="game_fps_summary">90Hz will be activated if Game Mode is enabled and 60Hz when disabled\nIt is for 60 Hz users who want 90 Hz only while gaming\nOnly works if your toggle is set to 60 Hz (obvious)</string>
     <string name="game_mode_notif_content">Game Mode is activated</string>
     <!-- Refresh rate -->
     <string name="refresh_title">Screen Refresh Rate</string>

--- a/res/xml/main.xml
+++ b/res/xml/main.xml
@@ -91,6 +91,12 @@
             android:title="@string/dnd_title"
             android:summary="@string/dnd_summary" />
 
+        <SwitchPreference
+            android:key="game_fps"
+            android:icon="@drawable/ic_info_outline_24dp"
+            android:title="@string/game_fps_title"
+            android:summary="@string/game_fps_summary" />
+
         <Preference
             android:key="doze"
             android:title="@string/ambient_display_gestures_title"

--- a/src/com/realmeparts/DeviceSettings.java
+++ b/src/com/realmeparts/DeviceSettings.java
@@ -173,14 +173,14 @@ public class DeviceSettings extends PreferenceFragment
             if (!(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) && prefs.getBoolean("refresh_rate_90Forced", false)){
             mRefreshRate60.setEnabled(false);
             mRefreshRate90.setEnabled(false);
-            RefreshRateSwitch.setRefreshRateFinal(3);
+            RefreshRateSwitch.setRefreshRateFinal(2);
             }
             else if((Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) && prefs.getBoolean("refresh_rate_90Forced", false)){
             RefreshRateSwitch.isSmoothDisplayOnOnce = true;
             mRefreshRate60.setEnabled(false);
             mRefreshRate90.setEnabled(false);
-            }
             RefreshRateSwitch.setRefreshRateFinal(1);
+            }
         } else if ((prefs.getBoolean("refresh_rate_60", false))) {
             mRefreshRate90Forced.setEnabled(false);
             RefreshRateSwitch.setRefreshRateFinal(0);

--- a/src/com/realmeparts/services/GameModeTileService.java
+++ b/src/com/realmeparts/services/GameModeTileService.java
@@ -26,12 +26,21 @@ import android.service.quicksettings.Tile;
 import android.service.quicksettings.TileService;
 
 import androidx.preference.PreferenceManager;
+import android.os.Build;
+import android.os.IBinder;
+import android.os.Parcel;
+import android.os.RemoteException;
+import android.os.ServiceManager;
+import android.provider.Settings;
+import android.util.Log;
 
 @TargetApi(24)
 public class GameModeTileService extends TileService {
     private boolean enabled = false;
     private Context mContext;
     private NotificationManager mNotificationManager;
+
+    private IBinder SF = ServiceManager.getService("SurfaceFlinger");
 
     @Override
     public void onDestroy() {
@@ -68,7 +77,6 @@ public class GameModeTileService extends TileService {
         mNotificationManager = (NotificationManager) this.getSystemService(Context.NOTIFICATION_SERVICE);
         SharedPreferences sharedPrefs = PreferenceManager.getDefaultSharedPreferences(this);
         enabled = GameModeSwitch.isCurrentlyEnabled(this);
-        //DeviceSettings.mGameModeSwitch.setChecked(!enabled);
         if (!enabled) {
             AppNotification.Send(this, GameModeSwitch.GameMode_Notification_Channel_ID, this.getString(R.string.game_mode_title), this.getString(R.string.game_mode_notif_content));
         } else AppNotification.Cancel(this, GameModeSwitch.GameMode_Notification_Channel_ID);
@@ -77,7 +85,9 @@ public class GameModeTileService extends TileService {
         Utils.writeValue(DeviceSettings.TP_DIRECTION, enabled ? "0" : "1");
         SystemProperties.set("perf_profile", enabled ? "0" : "1");
         if (sharedPrefs.getBoolean("dnd", false)) GameModeTileDND();
-        GameModeSwitch.gameFPS(!enabled);
+
+        if (sharedPrefs.getBoolean("game_fps", false)) GameModeTileGameFPS(!enabled);
+
         sharedPrefs.edit().putBoolean(DeviceSettings.KEY_GAME_SWITCH, !enabled).commit();
         getQsTile().setState(enabled ? Tile.STATE_INACTIVE : Tile.STATE_ACTIVE);
         getQsTile().updateTile();
@@ -93,6 +103,25 @@ public class GameModeTileService extends TileService {
             case 0:
                 mNotificationManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_ALL);
                 break;
+        }
+    }
+
+    private void GameModeTileGameFPS(boolean enabled) {
+      Settings.System.putFloat(this.getContentResolver(), "PEAK_REFRESH_RATE".toLowerCase(), enabled ? 90f : 60f);
+      Settings.System.putFloat(this.getContentResolver(), "MIN_REFRESH_RATE".toLowerCase(), enabled ? 90f : 60f);
+      setForcedRefreshRate((Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) ? (enabled ? 1 : 0) : (enabled ? 0 : -1));
+    }
+
+    public void setForcedRefreshRate(int value) {
+        Parcel Info = Parcel.obtain();
+        Info.writeInterfaceToken("android.ui.ISurfaceComposer");
+        Info.writeInt(value);
+        try {
+            SF.transact(1035, Info, null, 0);
+        } catch (RemoteException e) {
+            Log.e("DeviceSettings", e.toString());
+        } finally {
+            Info.recycle();
         }
     }
 }

--- a/src/com/realmeparts/services/GameModeTileService.java
+++ b/src/com/realmeparts/services/GameModeTileService.java
@@ -68,6 +68,7 @@ public class GameModeTileService extends TileService {
         mNotificationManager = (NotificationManager) this.getSystemService(Context.NOTIFICATION_SERVICE);
         SharedPreferences sharedPrefs = PreferenceManager.getDefaultSharedPreferences(this);
         enabled = GameModeSwitch.isCurrentlyEnabled(this);
+        //DeviceSettings.mGameModeSwitch.setChecked(!enabled);
         if (!enabled) {
             AppNotification.Send(this, GameModeSwitch.GameMode_Notification_Channel_ID, this.getString(R.string.game_mode_title), this.getString(R.string.game_mode_notif_content));
         } else AppNotification.Cancel(this, GameModeSwitch.GameMode_Notification_Channel_ID);
@@ -76,6 +77,7 @@ public class GameModeTileService extends TileService {
         Utils.writeValue(DeviceSettings.TP_DIRECTION, enabled ? "0" : "1");
         SystemProperties.set("perf_profile", enabled ? "0" : "1");
         if (sharedPrefs.getBoolean("dnd", false)) GameModeTileDND();
+        GameModeSwitch.gameFPS(!enabled);
         sharedPrefs.edit().putBoolean(DeviceSettings.KEY_GAME_SWITCH, !enabled).commit();
         getQsTile().setState(enabled ? Tile.STATE_INACTIVE : Tile.STATE_ACTIVE);
         getQsTile().updateTile();

--- a/src/com/realmeparts/switch/GameModeSwitch.java
+++ b/src/com/realmeparts/switch/GameModeSwitch.java
@@ -28,6 +28,8 @@ import androidx.preference.Preference;
 import androidx.preference.Preference.OnPreferenceChangeListener;
 import androidx.preference.PreferenceManager;
 
+import android.provider.Settings;
+
 public class GameModeSwitch implements OnPreferenceChangeListener {
     public static final int GameMode_Notification_Channel_ID = 0x11011;
     private static final String FILE = "/proc/touchpanel/game_switch_enable";
@@ -87,6 +89,29 @@ public class GameModeSwitch implements OnPreferenceChangeListener {
                 new NotificationManager.Policy(NotificationManager.Policy.PRIORITY_CATEGORY_MEDIA, 0, 0));
     }
 
+    public static boolean getIsSmoothDisplayOnOnce() {
+        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(mContext);
+        return sharedPreferences.getBoolean("refresh_rate_90Forced", false);
+    }
+
+    public static void gameFPS(boolean enabled) {
+        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(mContext);
+
+        if (DeviceSettings.mGameFPS.isEnabled() && sharedPreferences.getBoolean("game_fps", false)) {
+          RefreshRateSwitch.setRefreshRateFinal(enabled ? 1 : 0);
+          if (enabled){DeviceSettings.mRefreshRate60.setChecked(false);
+                     DeviceSettings.mRefreshRate90.setChecked(true);
+                     sharedPreferences.edit().putBoolean("refresh_rate_90", true).apply();
+                     sharedPreferences.edit().putBoolean("refresh_rate_60", false).apply();
+                   }
+          else {DeviceSettings.mRefreshRate60.setChecked(true);
+                    DeviceSettings.mRefreshRate90.setChecked(false);
+                    sharedPreferences.edit().putBoolean("refresh_rate_90", false).apply();
+                    sharedPreferences.edit().putBoolean("refresh_rate_60", true).apply();
+                  }
+        }
+    }
+
     public static void ShowToast() {
         if (isCurrentlyEnabled(mContext)) {
             Toast.makeText(mContext, "GameMode is activated. ", Toast.LENGTH_SHORT).show();
@@ -101,6 +126,7 @@ public class GameModeSwitch implements OnPreferenceChangeListener {
         Utils.writeValue(DeviceSettings.TP_DIRECTION, enabled ? "1" : "0");
         SystemProperties.set("perf_profile", enabled ? "1" : "0");
         GameModeDND();
+        gameFPS(enabled);
         return true;
     }
 }


### PR DESCRIPTION
* Will switch to 60 Hz when game mode is disabled
* It is for 60 Hz users who want 90 Hz only while gaming
* If your toggle is 90 Hz or Smooth display, then Game FPS will do 
nothing as it will consider you as full time 90 Hz user